### PR TITLE
Fix cross-platform errors (fixes for windows)

### DIFF
--- a/actions/general_actions.go
+++ b/actions/general_actions.go
@@ -5,6 +5,7 @@ import (
 	"github.com/madridianfox/elc/core"
 )
 
+// TODO fix it to with one other todocomment
 func UpdateBinaryAction(version string) error {
 	env := make([]string, 0)
 	if version != "" {

--- a/actions/workspace_actions_test.go
+++ b/actions/workspace_actions_test.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"github.com/madridianfox/elc/core"
 	"os"
 	"testing"
@@ -19,8 +20,8 @@ func TestWorkspaceList(t *testing.T) {
 	mockPc := setupMockPc(t)
 	expectReadHomeConfig(mockPc)
 
-	mockPc.EXPECT().Printf("%-10s %s\n", "project1", "/tmp/workspaces/project1")
-	mockPc.EXPECT().Printf("%-10s %s\n", "project2", "/tmp/workspaces/project2")
+	mockPc.EXPECT().Printf("%-10s %s\n", "project1", fmt.Sprintf("%s/workspaces/project1", os.TempDir()))
+	mockPc.EXPECT().Printf("%-10s %s\n", "project2", fmt.Sprintf("%s/workspaces/project2", os.TempDir()))
 
 	_ = ListWorkspacesAction()
 }
@@ -29,40 +30,40 @@ func TestWorkspaceAdd(t *testing.T) {
 	mockPc := setupMockPc(t)
 	expectReadHomeConfig(mockPc)
 
-	const homeConfigForAdd = `current_workspace: project1
+	var homeConfigForAdd = fmt.Sprintf(`current_workspace: project1
 update_command: update
 workspaces:
 - name: project1
-  path: /tmp/workspaces/project1
+  path: %s/workspaces/project1
   root_path: ""
 - name: project2
-  path: /tmp/workspaces/project2
+  path: %s/workspaces/project2
   root_path: ""
 - name: project3
-  path: /tmp/workspaces/project3
+  path: %s/workspaces/project3
   root_path: ""
-`
+`, os.TempDir(), os.TempDir(), os.TempDir())
 
 	mockPc.EXPECT().WriteFile(fakeHomeConfigPath, []byte(homeConfigForAdd), os.FileMode(0644))
 	mockPc.EXPECT().Printf("workspace '%s' is added\n", "project3")
 
-	_ = AddWorkspaceAction("project3", "/tmp/workspaces/project3")
+	_ = AddWorkspaceAction("project3", fmt.Sprintf("%s/workspaces/project3", os.TempDir()))
 }
 
 func TestWorkspaceSelect(t *testing.T) {
 	mockPc := setupMockPc(t)
 	expectReadHomeConfig(mockPc)
 
-	const homeConfigForSelect = `current_workspace: project2
+	var homeConfigForSelect = fmt.Sprintf(`current_workspace: project2
 update_command: update
 workspaces:
 - name: project1
-  path: /tmp/workspaces/project1
+  path: %s/workspaces/project1
   root_path: ""
 - name: project2
-  path: /tmp/workspaces/project2
+  path: %s/workspaces/project2
   root_path: ""
-`
+`, os.TempDir(), os.TempDir())
 
 	mockPc.EXPECT().WriteFile(fakeHomeConfigPath, []byte(homeConfigForSelect), os.FileMode(0644))
 	mockPc.EXPECT().Printf("active workspace changed to '%s'\n", "project2")

--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"path"
+	"path/filepath"
 )
 
 func CheckAndLoadHC() (*HomeConfig, error) {
@@ -9,7 +9,7 @@ func CheckAndLoadHC() (*HomeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	homeConfigPath := path.Join(homeDir, ".elc.yaml")
+	homeConfigPath := filepath.Join(homeDir, ".elc.yaml")
 	err = CheckHomeConfigIsEmpty(homeConfigPath)
 	if err != nil {
 		return nil, err

--- a/core/component_config.go
+++ b/core/component_config.go
@@ -25,6 +25,7 @@ type ComponentConfig struct {
 	Path           string              `yaml:"path"`
 	Replace        bool                `yaml:"replace"`
 	Variables      yaml.MapSlice       `yaml:"variables"`
+	PathVariables  []string            `yaml:"path_variables"`
 	Repository     string              `yaml:"repository"`
 	Tags           []string            `yaml:"tags"`
 	AfterCloneHook string              `yaml:"after_clone_hook"`

--- a/core/context.go
+++ b/core/context.go
@@ -42,6 +42,5 @@ func (ctx *Context) renderMapToEnv() []string {
 	for _, pair := range *ctx {
 		result = append(result, fmt.Sprintf("%s=%s", pair[0], pair[1]))
 	}
-
 	return result
 }

--- a/core/home-config.go
+++ b/core/home-config.go
@@ -20,6 +20,7 @@ type HomeConfig struct {
 	Workspaces       []HomeConfigItem `yaml:"workspaces"`
 }
 
+// DefaultUpdateCommand TODO может сделать подпрограмму elc-updater ? (второстепенное)
 const DefaultUpdateCommand = "curl -sSL https://raw.githubusercontent.com/ensi-platform/elc/master/get.sh | sudo -E bash"
 
 func LoadHomeConfig(configPath string) (*HomeConfig, error) {

--- a/core/workspace_config.go
+++ b/core/workspace_config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"gopkg.in/yaml.v2"
+	"path/filepath"
 )
 
 type WorkspaceConfig struct {
@@ -9,6 +10,7 @@ type WorkspaceConfig struct {
 	ElcMinVersion string                     `yaml:"elc_min_version"`
 	Components    map[string]ComponentConfig `yaml:"components"`
 	Variables     yaml.MapSlice              `yaml:"variables"`
+	PathVariables []string                   `yaml:"path_variables"`
 
 	// deprecated
 	Aliases map[string]string `yaml:"aliases"`
@@ -48,6 +50,14 @@ func (wsc *WorkspaceConfig) normalize() {
 	wsc.Modules = nil
 }
 
+func (wsc *WorkspaceConfig) normailizeComponentPaths() {
+	for _, v := range wsc.Components {
+		v.ComposeFile = filepath.FromSlash(v.ComposeFile)
+		v.ExecPath = filepath.FromSlash(v.ExecPath)
+		v.Path = filepath.FromSlash(v.Path)
+	}
+}
+
 func (wsc WorkspaceConfig) merge(wsc2 WorkspaceConfig) WorkspaceConfig {
 	for name, cc := range wsc2.Components {
 		if _, exists := wsc.Components[name]; !exists {
@@ -84,6 +94,7 @@ func (wsc *WorkspaceConfig) loadFromFile(wscPath string) error {
 	}
 
 	wsc.normalize()
+	wsc.normailizeComponentPaths()
 
 	return nil
 }


### PR DESCRIPTION
Fixed paths for windows (support for unix and windows paths using go standard library) and fixed tests. Also added `path_variables` to workspace configs, so all variables listed in `path_variables` will be normalized (we can see them via `elc vars` command).